### PR TITLE
Added static class members as part of interface

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -261,8 +261,8 @@ export class Parser {
         const properties = constructorType.getProperties();
         if (properties) {
             constructorType.getProperties().forEach(property => {
-                // Only add members, don't add non-member properties
-                if (this.getCallSignature(symbol)) {
+                // Don't add class prototype definitions
+                if (property.name !== 'prototype') {
 
                     this.addMemberDoc(details, property);
                 }


### PR DESCRIPTION
Solves an issue with the status page not showing static class member methods of the [VS Code API](https://code.visualstudio.com/api/references/vscode-api)

Example of missing methods
```
Uri#
A universal resource identifier representing either a file on disk or another resource, like untitled resources.

STATIC
file(path: string): Uri

joinPath(base: Uri, ...pathSegments: string[]): Uri

parse(value: string, strict?: boolean): Uri
```

Contributed by STMicroelectronics

Signed-off-by: Niklas DAHLQUIST <niklas.dahlquist@st.com>